### PR TITLE
Added proper handling of type argument in detect_outlier

### DIFF
--- a/R/qc.R
+++ b/R/qc.R
@@ -49,8 +49,8 @@
 #' #TODO
 #'
 detect_outlier = function(scd,
-                          comp=1,
-                          sel_col=NULL,
+                          comp = 1,
+                          sel_col = NULL,
                           type = c("both", "low", "high"),
                           conf = c(0.9, 0.99)){
   type <- match.arg(type)
@@ -109,7 +109,7 @@ detect_outlier = function(scd,
     keep1[keep][mod$classification %in% poor_comp] = FALSE
     keep1[!keep] = FALSE
     sub_x = x[keep1,]
-    covr <- covMcd(sub_x, alpha=0.7)
+    covr = covMcd(sub_x, alpha=0.7)
     sub_dist = mahalanobis(sub_x,
                            center=covr$center,
                            cov=covr$cov)
@@ -141,7 +141,6 @@ detect_outlier = function(scd,
 }
 
 
-
 #' get QC metrics using gene counting matrix
 #'
 #' @param scd an SCData object containing count
@@ -155,7 +154,6 @@ detect_outlier = function(scd,
 #' `non_ribo_percent`: 1- percent of ribosomal gene counts
 #' ribosomal genes are retrived by GO term GO:0005840
 #' @return no return
-#'
 #'
 #' @export
 #' @examples

--- a/R/qc.R
+++ b/R/qc.R
@@ -53,6 +53,8 @@ detect_outlier = function(scd,
                           sel_col=NULL,
                           type = c("both", "low", "high"),
                           conf = c(0.9, 0.99)){
+  type <- match.arg(type)
+
   # check format:
   if (is(scd, "SCData")){
     if (is.null(sel_col)){


### PR DESCRIPTION
When using arguments of the form `arg = c("opt1", "opt2", "opt3")` there should be a corresponding `arg = match.arg(arg)` line somewhere in the function body. [See here](https://stat.ethz.ch/R-manual/R-devel/library/base/html/match.arg.html). Without this the line

```
if(type == "both")
```

will give the error
> the condition has length > 1 and only the first element will be used