### PR TITLE
Added zlibbioc lines

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,4 +1,14 @@
 RHTSLIB_LIBS=$(shell echo 'Rhtslib::pkgconfig("PKG_LIBS")'|\
-    "${R_HOME}/bin/R" --vanilla --slave)
+	"${R_HOME}/bin/R" --vanilla --slave)
 PKG_LIBS=$(RHTSLIB_LIBS)
 CXX_STD = CXX11
+
+ZLIB_CFLAGS+=$(shell echo 'zlibbioc::pkgconfig("PKG_CFLAGS")'|\
+	"${R_HOME}/bin/R" --vanilla --slave)
+PKG_LIBS+=$(shell echo 'zlibbioc::pkgconfig("PKG_LIBS_shared")' |\
+	"${R_HOME}/bin/R" --vanilla --slave)
+%.o: %.c
+	$(CC) $(ZLIB_CFLAGS) $(ALL_CPPFLAGS) $(ALL_CFLAGS) -c $< -o $@
+
+%.o: %.cpp
+	$(CXX) $(ZLIB_CFLAGS) $(ALL_CPPFLAGS) $(ALL_CXXFLAGS) -c $< -o $@


### PR DESCRIPTION
Added Makevar.win lines to fix some linking errors. Code taken from [zlibbioc documentation.](http://bioconductor.org/packages/release/bioc/vignettes/zlibbioc/inst/doc/UsingZlibbioc.pdf) Moves us forward one stop into scPipe.DLL error.