### PR TITLE
Fixed handling of colData when assigning to QC_metrics

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -17,7 +17,7 @@ rcpp_sc_gene_counting <- function(outdir, bc_anno, UMI_cor, gene_fl) {
     invisible(.Call('_scPipe_rcpp_sc_gene_counting', PACKAGE = 'scPipe', outdir, bc_anno, UMI_cor, gene_fl))
 }
 
-rcpp_sc_detect_bc <- function(infq, outcsv, surfix, bc_len, max_reads, min_count, max_mismatch) {
-    invisible(.Call('_scPipe_rcpp_sc_detect_bc', PACKAGE = 'scPipe', infq, outcsv, surfix, bc_len, max_reads, min_count, max_mismatch))
+rcpp_sc_detect_bc <- function(infq, outcsv, suffix, bc_len, max_reads, min_count, max_mismatch) {
+    invisible(.Call('_scPipe_rcpp_sc_detect_bc', PACKAGE = 'scPipe', infq, outcsv, suffix, bc_len, max_reads, min_count, max_mismatch))
 }
 

--- a/R/SCE_methods.R
+++ b/R/SCE_methods.R
@@ -70,11 +70,10 @@ validObject = function(object){
 #'
 QC_metrics.sce <- function(object) {
   if(!("scPipe" %in% names(object@metadata))){
-    warning("`scPipe` not in `metadata`. cannot identify quality control columns")
+    warning("`scPipe` not in `metadata`. Cannot identify quality control columns")
     return(NULL)
-  }else if(!("QC_cols" %in% names(object@metadata$scPipe))){
-    warning("The metadata$scPipe does not have `QC_cols`. 
-      cannot identifyquality control  columns")
+  } else if (!("QC_cols" %in% names(object@metadata$scPipe))) {
+    warning("metadata$scPipe is missing `QC_cols`. Cannot identify quality control columns")
     return(NULL)
   }
   return(colData(object)[, object@metadata$scPipe$QC_cols])
@@ -90,17 +89,21 @@ setMethod("QC_metrics", signature(object = "SingleCellExperiment"),
 #' @rdname QC_metrics
 #' @aliases QC_metrics
 #' @export
-setReplaceMethod("QC_metrics",
-                 signature="SingleCellExperiment",
-                 function(object, value) {
-                   if(!("scPipe" %in% names(object@metadata))){
-                     object@metadata[["scPipe"]] = list(QC_cols=colnames(value))
-                   }else{
-                     object@metadata$scPipe$QC_cols = colnames(value)
-                   }
-                   colData(object) = DataFrame(value)
-                   return(object)
-                 })
+setReplaceMethod(
+  "QC_metrics",
+  signature = "SingleCellExperiment",
+  function(object, value) {
+    if (!("scPipe" %in% names(object@metadata))) {
+      object@metadata[["scPipe"]] = list(QC_cols=colnames(value))
+    } else {
+      object@metadata$scPipe$QC_cols = colnames(value)
+    }
+
+    colData(object)[, colnames(value)] <- DataFrame(value)
+
+    return(object)
+  }
+)
 
 
 #' @title demultiplex_info

--- a/R/wrapper_scPipeCPP.R
+++ b/R/wrapper_scPipeCPP.R
@@ -254,7 +254,7 @@ sc_gene_counting = function(outdir, bc_anno, UMI_cor=1, gene_fl=FALSE) {
 #' @param infq input fastq file, shoule be the output file of 
 #' \code{sc_trim_barcode}
 #' @param outcsv output barcode annotation
-#' @param surfix the surfix of cell name, default to be `CELL_`. The cell name
+#' @param suffix the suffix of cell name, default to be `CELL_`. The cell name
 #' will be CELL_001, CELL_002 accordingly.
 #' @param bc_len the length of cell barcode, should be consistent with bl1+bl2
 #' in \code{sc_trim_barcode}
@@ -276,10 +276,10 @@ sc_gene_counting = function(outdir, bc_anno, UMI_cor=1, gene_fl=FALSE) {
 #' }
 #' 
 #' 
-sc_detect_bc = function(infq, outcsv, surfix="CELL_", bc_len, 
+sc_detect_bc = function(infq, outcsv, suffix="CELL_", bc_len, 
                         max_reads=1000000, min_count=10, max_mismatch=1) {
   if (!file.exists(infq)) {stop("input fastq file does not exists.")}
   if (max_reads=="all") {m_r = -1}
   else {m_r=max_reads}
-  rcpp_sc_detect_bc(infq, outcsv, surfix, bc_len, m_r, min_count, max_mismatch)
+  rcpp_sc_detect_bc(infq, outcsv, suffix, bc_len, m_r, min_count, max_mismatch)
 }

--- a/man/sc_detect_bc.Rd
+++ b/man/sc_detect_bc.Rd
@@ -4,7 +4,7 @@
 \alias{sc_detect_bc}
 \title{sc_detect_bc}
 \usage{
-sc_detect_bc(infq, outcsv, surfix = "CELL_", bc_len, max_reads = 1e+06,
+sc_detect_bc(infq, outcsv, suffix = "CELL_", bc_len, max_reads = 1e+06,
   min_count = 10, max_mismatch = 1)
 }
 \arguments{
@@ -13,7 +13,7 @@ sc_detect_bc(infq, outcsv, surfix = "CELL_", bc_len, max_reads = 1e+06,
 
 \item{outcsv}{output barcode annotation}
 
-\item{surfix}{the surfix of cell name, default to be `CELL_`. The cell name
+\item{suffix}{the suffix of cell name, default to be `CELL_`. The cell name
 will be CELL_001, CELL_002 accordingly.}
 
 \item{bc_len}{the length of cell barcode, should be consistent with bl1+bl2

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -80,18 +80,18 @@ BEGIN_RCPP
 END_RCPP
 }
 // rcpp_sc_detect_bc
-void rcpp_sc_detect_bc(Rcpp::CharacterVector infq, Rcpp::CharacterVector outcsv, Rcpp::CharacterVector surfix, Rcpp::NumericVector bc_len, Rcpp::NumericVector max_reads, Rcpp::NumericVector min_count, Rcpp::NumericVector max_mismatch);
-RcppExport SEXP _scPipe_rcpp_sc_detect_bc(SEXP infqSEXP, SEXP outcsvSEXP, SEXP surfixSEXP, SEXP bc_lenSEXP, SEXP max_readsSEXP, SEXP min_countSEXP, SEXP max_mismatchSEXP) {
+void rcpp_sc_detect_bc(Rcpp::CharacterVector infq, Rcpp::CharacterVector outcsv, Rcpp::CharacterVector suffix, Rcpp::NumericVector bc_len, Rcpp::NumericVector max_reads, Rcpp::NumericVector min_count, Rcpp::NumericVector max_mismatch);
+RcppExport SEXP _scPipe_rcpp_sc_detect_bc(SEXP infqSEXP, SEXP outcsvSEXP, SEXP suffixSEXP, SEXP bc_lenSEXP, SEXP max_readsSEXP, SEXP min_countSEXP, SEXP max_mismatchSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type infq(infqSEXP);
     Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type outcsv(outcsvSEXP);
-    Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type surfix(surfixSEXP);
+    Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type suffix(suffixSEXP);
     Rcpp::traits::input_parameter< Rcpp::NumericVector >::type bc_len(bc_lenSEXP);
     Rcpp::traits::input_parameter< Rcpp::NumericVector >::type max_reads(max_readsSEXP);
     Rcpp::traits::input_parameter< Rcpp::NumericVector >::type min_count(min_countSEXP);
     Rcpp::traits::input_parameter< Rcpp::NumericVector >::type max_mismatch(max_mismatchSEXP);
-    rcpp_sc_detect_bc(infq, outcsv, surfix, bc_len, max_reads, min_count, max_mismatch);
+    rcpp_sc_detect_bc(infq, outcsv, suffix, bc_len, max_reads, min_count, max_mismatch);
     return R_NilValue;
 END_RCPP
 }

--- a/src/detect_barcode.cpp
+++ b/src/detect_barcode.cpp
@@ -98,14 +98,14 @@ std::unordered_map<std::string, int> summarize_barcode(std::string fn, int bc_le
     return counter;
 }
 
-void write_barcode_summary(std::string outfn, std::string surfix, std::unordered_map<std::string, int> counter)
+void write_barcode_summary(std::string outfn, std::string suffix, std::unordered_map<std::string, int> counter)
 {
     std::ofstream o_file(outfn);  // output file
     int cnt = 0;
     int dig = std::to_string(counter.size()).length()+1;
     for (auto const& bc: counter)
     {
-        o_file << surfix << padding(cnt, dig) << "," << bc.first << "," << bc.second << std::endl;
+        o_file << suffix << padding(cnt, dig) << "," << bc.first << "," << bc.second << std::endl;
         cnt++;
     }
 }

--- a/src/rcpp_scPipe_func.cpp
+++ b/src/rcpp_scPipe_func.cpp
@@ -163,7 +163,7 @@ void rcpp_sc_gene_counting(Rcpp::CharacterVector outdir,
 
 void rcpp_sc_detect_bc(Rcpp::CharacterVector infq,
                            Rcpp::CharacterVector outcsv,
-                           Rcpp::CharacterVector surfix,
+                           Rcpp::CharacterVector suffix,
                            Rcpp::NumericVector bc_len,
                            Rcpp::NumericVector max_reads,
                            Rcpp::NumericVector min_count,
@@ -171,7 +171,7 @@ void rcpp_sc_detect_bc(Rcpp::CharacterVector infq,
 {
   std::string c_infq = Rcpp::as<std::string>(infq);
   std::string c_outcsv = Rcpp::as<std::string>(outcsv);
-  std::string c_surfix = Rcpp::as<std::string>(surfix);
+  std::string c_suffix = Rcpp::as<std::string>(suffix);
   int c_bc_len = Rcpp::as<int>(bc_len);
   int c_max_reads = Rcpp::as<int>(max_reads);
   int c_min_count = Rcpp::as<int>(min_count);
@@ -179,6 +179,6 @@ void rcpp_sc_detect_bc(Rcpp::CharacterVector infq,
   
   
   std::unordered_map<std::string, int> counter = summarize_barcode(c_infq, c_bc_len, c_max_reads, c_max_mismatch, c_min_count);
-  write_barcode_summary(c_outcsv, c_surfix, counter);
+  write_barcode_summary(c_outcsv, c_suffix, counter);
 }
 


### PR DESCRIPTION
* Previously the `QC_metrics<-` assignment causes everything in `colData` to be overwritten. Now it writes only to columns defined by the `QC_cols` so it retains all the data. [Code](https://github.com/LuyiTian/scPipe/compare/master...Shians:master#diff-1f697da1c7e3b13bd8dc815b7a0445b6R92)

* Fixed some spelling and grammar