### PR TITLE
Fixed bugs in slim report and trimbarcode error message

### DIFF
--- a/R/SCE_methods.R
+++ b/R/SCE_methods.R
@@ -43,8 +43,8 @@ validObject = function(object){
                   "/",
                   tmp_res$gene_id_type))
     }else{
-      gene_id_type(object) = NA
-      organism(object) = NA
+      gene_id_type(object) = "NA"
+      organism(object) = "NA"
     } 
   }
   return(object)

--- a/R/qc.R
+++ b/R/qc.R
@@ -110,10 +110,10 @@ detect_outlier <- function(sce,
       stop("did not find column `batch` in colData(sce).")
     }
   }
-  
+
   if(any(rowSums(x_all) == 0)){
     stop("Some cells have zero counts. remove these cells before detecting outlier.")
-  }else if(any(colSums(x_all) == 0){
+  }else if(any(colSums(x_all) == 0)){
     stop("Some QC metrics are all zeros, check your quality control matrix by QC_metrics(sce).")
   }
   outliers <- rep(FALSE, nrow(x_all))

--- a/R/wrapper_scPipeCPP.R
+++ b/R/wrapper_scPipeCPP.R
@@ -84,6 +84,11 @@ sc_trim_barcode = function(outfq, r1, r2=NULL,
   if (!is.null(r2)) {
     if (!file.exists(r1)) {stop("read1 fastq file does not exists.")}
     if (!file.exists(r2)) {stop("read2 fastq file does not exists.")}
+
+    # expand tilde to home path for downstream gzopen() call
+    r1 = path.expand(r1)
+    r2 = path.expand(r2)
+
     rcpp_sc_trim_barcode_paired(outfq, r1, r2,
                                 read_structure$bs1,
                                 read_structure$bl1,

--- a/inst/extdata/report_template_slim.Rmd
+++ b/inst/extdata/report_template_slim.Rmd
@@ -54,7 +54,7 @@ ggplotly(plot_mapping(sce, percentage=FALSE))
 ```
 
 ```{r}
-ggplotly(plot_mapping(sce, dataname=params$samplename, percentage=TRUE))
+ggplotly(plot_mapping(sce, percentage=TRUE))
 ```
 
 ## Summary and distributions of QC metrics

--- a/src/trimbarcode.cpp
+++ b/src/trimbarcode.cpp
@@ -72,13 +72,13 @@ void paired_fastq_to_bam(char *fq1_fn, char *fq2_fn, char *bam_out, const read_s
     gzFile fq1 = gzopen(fq1_fn, "r"); // input fastq
     if (!fq1) {
         std::stringstream err_msg;
-        err_msg << "Can't open file: %s\n" << fq1_fn;
+        err_msg << "Can't open file: " << fq1_fn << "\n";
         Rcpp::stop(err_msg.str());
     }
     gzFile fq2 = gzopen(fq2_fn, "r");
     if (!fq2) {
         std::stringstream err_msg;
-        err_msg << "Can't open file: %s\n" << fq2_fn;
+        err_msg << "Can't open file: " << fq2_fn << "\n";
         Rcpp::stop(err_msg.str());
     }
 


### PR DESCRIPTION
* My [slim report](https://github.com/LuyiTian/scPipe/pull/43/files#diff-0e337ff80adaf28b06ea667e1e2531cbR57) shouldn't have a dataname param, forgot to delete it on the first round.
* Fixed incorrect [error message printing](https://github.com/LuyiTian/scPipe/pull/43/commits/6749247d73f4c8c8b3bb242a7c2ca86c82cece70#diff-6fc0c41231ed0ceb7a414d0fc5bea403R75).
* Fixed [missing bracket](https://github.com/LuyiTian/scPipe/pull/43/files#diff-a5e40c31bcdf4a0e6a8fbfcad3e32610R116).
* Fixed default [gene_id and organisms assignment](https://github.com/LuyiTian/scPipe/compare/master...Shians:master#diff-1f697da1c7e3b13bd8dc815b7a0445b6R46).
    * Assigning `= NA` causes vignette to not run, there's some kind of `if (value = "NA")` check somewhere which fails because `NA = "NA"` actually returns `NA` and not `TRUE`.
    * Changed to `= "NA"` default.
* Saskia reported that sc_trim_barcode doesn't like `~`, hopefully I've fixed it with [path.expand](https://github.com/LuyiTian/scPipe/pull/43/commits/ac05cab480e1a40a651779218fe006f10d06a5df#diff-aa23218ed4b0a0667d786f65e3099ee4R88). I think [gzopen](https://github.com/LuyiTian/scPipe/blob/master/src/trimbarcode.cpp#L72) isn't smart enough to expand the tilde on its own.