### PR TITLE
Temporarily disabled reporting

### DIFF
--- a/src/transcriptmapping.cpp
+++ b/src/transcriptmapping.cpp
@@ -3,6 +3,7 @@
 
 using std::atoi;
 using std::atomic;
+using std::endl;
 using std::fixed;
 using std::getline;
 using std::ifstream;
@@ -580,7 +581,7 @@ namespace {
 
             Rcout
                 << cnt << " reads processed" << ", "
-                << cnt / timer.seconds_elapsed() / 1000 << "k reads/sec" << "\n";
+                << cnt / timer.seconds_elapsed() / 1000 << "k reads/sec" << endl;
         } while (running);
     }
 }
@@ -633,11 +634,11 @@ void Mapping::parse_align(string fn, string fn_out, bool m_strand, string map_ta
 
     Rcout << "updating progress every 3 minutes..." << "\n";
     // spawn thread to report progress every 3 minutes
-    thread reporter_thread(
-        [&cnt, &running]() {
-            report_every_3_mins(cnt, running);
-        }
-    );
+    // thread reporter_thread(
+    //     [&cnt, &running]() {
+    //         report_every_3_mins(cnt, running);
+    //     }
+    // );
 
     while (bam_read1(fp, b) >= 0)
     {
@@ -704,7 +705,7 @@ void Mapping::parse_align(string fn, string fn_out, bool m_strand, string map_ta
     }
 
     running = false;
-    reporter_thread.join();
+    // reporter_thread.join();
 
     Rcout << "number of read processed: " << cnt << "\n";
     Rcout << "unique map to exon: " << tmp_c[0]


### PR DESCRIPTION
Reporting code causes some kind of stack error for large files. Disabled until further notice.