### PR TITLE
Added small parallelism to parse_align

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: scPipe
 Title: pipeline for single cell RNA-seq data analysis
 Date: 2018-05-22
-Version: 1.3.6
+Version: 1.3.7
 Type: Package
 Maintainer: Luyi Tian <tian.l@wehi.edu.au>
 Author: Luyi Tian

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -5,8 +5,8 @@ rcpp_sc_trim_barcode_paired <- function(outfq, r1, r2, bs1, bl1, bs2, bl2, us, u
     invisible(.Call(`_scPipe_rcpp_sc_trim_barcode_paired`, outfq, r1, r2, bs1, bl1, bs2, bl2, us, ul, rmlow, rmN, minq, numbq, write_gz))
 }
 
-rcpp_sc_exon_mapping <- function(inbam, outbam, annofn, am, ge, bc, mb, bc_len, bc_vector, UMI_len, stnd, fix_chr) {
-    invisible(.Call(`_scPipe_rcpp_sc_exon_mapping`, inbam, outbam, annofn, am, ge, bc, mb, bc_len, bc_vector, UMI_len, stnd, fix_chr))
+rcpp_sc_exon_mapping <- function(inbam, outbam, annofn, am, ge, bc, mb, bc_len, bc_vector, UMI_len, stnd, fix_chr, nthreads) {
+    invisible(.Call(`_scPipe_rcpp_sc_exon_mapping`, inbam, outbam, annofn, am, ge, bc, mb, bc_len, bc_vector, UMI_len, stnd, fix_chr, nthreads))
 }
 
 rcpp_sc_demultiplex <- function(inbam, outdir, bc_anno, max_mis, am, ge, bc, mb, mito, has_UMI) {

--- a/R/wrapper_scPipeCPP.R
+++ b/R/wrapper_scPipeCPP.R
@@ -169,7 +169,8 @@ sc_trim_barcode = function(outfq, r1, r2=NULL,
 #'
 sc_exon_mapping = function(inbam, outbam, annofn,
                             bam_tags = list(am="YE", ge="GE", bc="BC", mb="OX"),
-                            bc_len=8, barcode_vector="", UMI_len=6, stnd=TRUE, fix_chr=FALSE) {
+                            bc_len=8, barcode_vector="", UMI_len=6, stnd=TRUE, fix_chr=FALSE,
+                            nthreads=1) {
   if (stnd) {
     i_stnd = 1
   }
@@ -197,7 +198,7 @@ sc_exon_mapping = function(inbam, outbam, annofn,
   
 
   rcpp_sc_exon_mapping(inbam, outbam, annofn, bam_tags$am, bam_tags$ge, bam_tags$bc, bam_tags$mb, bc_len, 
-                       barcode_vector, UMI_len, stnd, fix_chr)
+                       barcode_vector, UMI_len, stnd, fix_chr, nthreads)
 }
 
 
@@ -462,7 +463,8 @@ sc_count_aligned_bam <- function(
   max_mis = 1,
   mito = "MT",
   has_UMI = TRUE, UMI_cor = 1, gene_fl = FALSE,
-  keep_mapped_bam = TRUE
+  keep_mapped_bam = TRUE,
+  nthreads = 1
 ) {
   sc_exon_mapping(
     inbam = inbam,
@@ -472,7 +474,8 @@ sc_count_aligned_bam <- function(
     bc_len = bc_len,
     UMI_len = UMI_len,
     stnd = stnd,
-    fix_chr = fix_chr
+    fix_chr = fix_chr,
+    nthreads = nthreads
   )
 
   sc_demultiplex_and_count(

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -29,8 +29,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // rcpp_sc_exon_mapping
-void rcpp_sc_exon_mapping(Rcpp::CharacterVector inbam, Rcpp::CharacterVector outbam, Rcpp::CharacterVector annofn, Rcpp::CharacterVector am, Rcpp::CharacterVector ge, Rcpp::CharacterVector bc, Rcpp::CharacterVector mb, Rcpp::NumericVector bc_len, Rcpp::CharacterVector bc_vector, Rcpp::NumericVector UMI_len, Rcpp::NumericVector stnd, Rcpp::NumericVector fix_chr);
-RcppExport SEXP _scPipe_rcpp_sc_exon_mapping(SEXP inbamSEXP, SEXP outbamSEXP, SEXP annofnSEXP, SEXP amSEXP, SEXP geSEXP, SEXP bcSEXP, SEXP mbSEXP, SEXP bc_lenSEXP, SEXP bc_vectorSEXP, SEXP UMI_lenSEXP, SEXP stndSEXP, SEXP fix_chrSEXP) {
+void rcpp_sc_exon_mapping(Rcpp::CharacterVector inbam, Rcpp::CharacterVector outbam, Rcpp::CharacterVector annofn, Rcpp::CharacterVector am, Rcpp::CharacterVector ge, Rcpp::CharacterVector bc, Rcpp::CharacterVector mb, Rcpp::NumericVector bc_len, Rcpp::CharacterVector bc_vector, Rcpp::NumericVector UMI_len, Rcpp::NumericVector stnd, Rcpp::NumericVector fix_chr, Rcpp::NumericVector nthreads);
+RcppExport SEXP _scPipe_rcpp_sc_exon_mapping(SEXP inbamSEXP, SEXP outbamSEXP, SEXP annofnSEXP, SEXP amSEXP, SEXP geSEXP, SEXP bcSEXP, SEXP mbSEXP, SEXP bc_lenSEXP, SEXP bc_vectorSEXP, SEXP UMI_lenSEXP, SEXP stndSEXP, SEXP fix_chrSEXP, SEXP nthreadsSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type inbam(inbamSEXP);
@@ -45,7 +45,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< Rcpp::NumericVector >::type UMI_len(UMI_lenSEXP);
     Rcpp::traits::input_parameter< Rcpp::NumericVector >::type stnd(stndSEXP);
     Rcpp::traits::input_parameter< Rcpp::NumericVector >::type fix_chr(fix_chrSEXP);
-    rcpp_sc_exon_mapping(inbam, outbam, annofn, am, ge, bc, mb, bc_len, bc_vector, UMI_len, stnd, fix_chr);
+    Rcpp::traits::input_parameter< Rcpp::NumericVector >::type nthreads(nthreadsSEXP);
+    rcpp_sc_exon_mapping(inbam, outbam, annofn, am, ge, bc, mb, bc_len, bc_vector, UMI_len, stnd, fix_chr, nthreads);
     return R_NilValue;
 END_RCPP
 }
@@ -104,7 +105,7 @@ RcppExport SEXP run_testthat_tests();
 
 static const R_CallMethodDef CallEntries[] = {
     {"_scPipe_rcpp_sc_trim_barcode_paired", (DL_FUNC) &_scPipe_rcpp_sc_trim_barcode_paired, 14},
-    {"_scPipe_rcpp_sc_exon_mapping", (DL_FUNC) &_scPipe_rcpp_sc_exon_mapping, 12},
+    {"_scPipe_rcpp_sc_exon_mapping", (DL_FUNC) &_scPipe_rcpp_sc_exon_mapping, 13},
     {"_scPipe_rcpp_sc_demultiplex", (DL_FUNC) &_scPipe_rcpp_sc_demultiplex, 10},
     {"_scPipe_rcpp_sc_gene_counting", (DL_FUNC) &_scPipe_rcpp_sc_gene_counting, 4},
     {"_scPipe_rcpp_sc_detect_bc", (DL_FUNC) &_scPipe_rcpp_sc_detect_bc, 9},

--- a/src/config_hts.h
+++ b/src/config_hts.h
@@ -6,6 +6,7 @@
 #include "htslib/sam.h"
 #include "htslib/bgzf.h"
 #include "htslib/kseq.h"
+#include "htslib/thread_pool.h"
 
 /*
 #include <htslib/sam.h>

--- a/src/rcpp_scPipe_func.cpp
+++ b/src/rcpp_scPipe_func.cpp
@@ -90,7 +90,8 @@ void rcpp_sc_exon_mapping(Rcpp::CharacterVector inbam,
                           Rcpp::CharacterVector bc_vector,
                           Rcpp::NumericVector UMI_len,
                           Rcpp::NumericVector stnd,
-                          Rcpp::NumericVector fix_chr)
+                          Rcpp::NumericVector fix_chr,
+                          Rcpp::NumericVector nthreads)
 {
   //std::string c_inbam = Rcpp::as<std::string>(inbam);
   std::string c_outbam = Rcpp::as<std::string>(outbam);
@@ -107,6 +108,8 @@ void rcpp_sc_exon_mapping(Rcpp::CharacterVector inbam,
   std::vector<std::string> c_inbam_vec = Rcpp::as<std::vector<std::string>>(inbam);
   std::vector<std::string> c_bc_vec = Rcpp::as<std::vector<std::string>>(bc_vector);
   std::vector<std::string> token = Rcpp::as<std::vector<std::string>>(annofn);
+  int c_nthreads = Rcpp::as<int>(nthreads);
+
   Mapping a = Mapping();
   Rcpp::Rcout << "adding annotation files..." << "\n";
 
@@ -121,7 +124,7 @@ void rcpp_sc_exon_mapping(Rcpp::CharacterVector inbam,
   Rcpp::Rcout << "annotating exon features..." << "\n";
 
   timer.start();
-  a.parse_align_warpper(c_inbam_vec, c_bc_vec, c_outbam, c_stnd, c_am, c_ge, c_bc, c_mb, c_bc_len, c_UMI_len);
+  a.parse_align_warpper(c_inbam_vec, c_bc_vec, c_outbam, c_stnd, c_am, c_ge, c_bc, c_mb, c_bc_len, c_UMI_len, c_nthreads);
   //a.parse_align(c_inbam, c_outbam, c_stnd, c_am, c_ge, c_bc, c_mb, c_bc_len, c_UMI_len);
 
   Rcpp::Rcout << "time elapsed: " << timer.time_elapsed() << "\n\n";

--- a/src/transcriptmapping.cpp
+++ b/src/transcriptmapping.cpp
@@ -621,10 +621,10 @@ void Mapping::parse_align_warpper(vector<string> fn_vec, vector<string> cell_id_
     }
     else
     {
-      parse_align(fn_vec[0], fn_out, m_strand, map_tag, gene_tag, cellular_tag, molecular_tag, bc_len, "wb", "", UMI_len);
+      parse_align(fn_vec[0], fn_out, m_strand, map_tag, gene_tag, cellular_tag, molecular_tag, bc_len, "wb", "", UMI_len, nthreads);
       for (int i=1;i<fn_vec.size();i++)
       {
-        parse_align(fn_vec[i], fn_out, m_strand, map_tag, gene_tag, cellular_tag, molecular_tag, bc_len, "ab", "", UMI_len);
+        parse_align(fn_vec[i], fn_out, m_strand, map_tag, gene_tag, cellular_tag, molecular_tag, bc_len, "ab", "", UMI_len, nthreads);
       }
     }
   }

--- a/src/transcriptmapping.h
+++ b/src/transcriptmapping.h
@@ -194,12 +194,12 @@ public:
     //  4 - unaligned
     int map_exon(bam_hdr_t *header, bam1_t *b, std::string& gene_id, bool m_strand);
 
-    void parse_align_warpper(std::vector<std::string> fn_vec, std::vector<std::string> cell_id_vec, std::string fn_out, bool m_strand, std::string map_tag, std::string gene_tag, std::string cellular_tag, std::string molecular_tag, int bc_len, int UMI_len);
+    void parse_align_warpper(std::vector<std::string> fn_vec, std::vector<std::string> cell_id_vec, std::string fn_out, bool m_strand, std::string map_tag, std::string gene_tag, std::string cellular_tag, std::string molecular_tag, int bc_len, int UMI_len, int nthreads);
     // @param: m_strand, match based on strand or not
     // @param: fn_out, output bam file
     // @param: write_mode, whether to write (wb) or attach (ab) to a bam file.
     // @param: cell_id, to provide the cell barcode, if not in the header of fastq file.
-    void parse_align(std::string fn, std::string fn_out, bool m_strand, std::string map_tag, std::string gene_tag, std::string cellular_tag, std::string molecular_tag, int bc_len, std::string write_mode, std::string cell_id, int UMI_len);
+    void parse_align(std::string fn, std::string fn_out, bool m_strand, std::string map_tag, std::string gene_tag, std::string cellular_tag, std::string molecular_tag, int bc_len, std::string write_mode, std::string cell_id, int UMI_len, int nthreads);
 
     /* data */
 };

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -18,15 +18,12 @@ string join_path(const string p1, const string p2)
 	return p1.back() == sep ? p1 + p2 : p1 + sep + p2;
 }
 
-int hamming_distance(string A, string B)
+int hamming_distance(const string &A, const string &B)
 {
     int dist = 0;
     for (int i = 0; i < A.length(); ++i)
     {
-        if (A[i] != B[i])
-        {
-            dist++;
-        }
+        dist += (A[i] != B[i]);
     }
     return dist;
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -20,7 +20,7 @@ std::string join_path(const std::string p1, const std::string p2);
 
 // calculate hamming distance of two strings A and B
 // two strings should have equal length
-int hamming_distance(std::string A, std::string B);
+int hamming_distance(const std::string &A, const std::string &B);
 
 // since htslib does not validate file status we 
 // need to check ourself


### PR DESCRIPTION
So htslib has a parallelism option discussed [here](https://github.com/samtools/htslib/issues/663). I've integrated this into the code by adding a `nthreads` argument to multiple places and initialising the htslib thread pool.

* Added htslib [thread pool](https://github.com/LuyiTian/scPipe/compare/master...Shians:parallel?expand=1#diff-a06a45a6fa7d4ce7ddf61c93eed3944bR9) include.
* Added nthreads arguments to `parse_align` and all upstream functions that call it.
* Added initialisation of a [thread pool](https://github.com/LuyiTian/scPipe/compare/master...Shians:parallel?expand=1#diff-354660c2b347e143850fb11b58e72e25R650) for the BAM output in parse_align.

This results in a significant speed up of the `parse_align` step in my testing, close to division by the number of threads used.

* Changed hamming_distance to take arguments by reference. This halves the time it takes to do demultiplexing.