### PR TITLE
Corrected "suffix" argument in sc_detect_bc

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: scPipe
 Title: pipeline for single cell RNA-seq data analysis
 Date: 2018-05-22
-Version: 1.3.7
+Version: 1.3.8
 Type: Package
 Maintainer: Luyi Tian <tian.l@wehi.edu.au>
 Author: Luyi Tian

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -17,7 +17,7 @@ rcpp_sc_gene_counting <- function(outdir, bc_anno, UMI_cor, gene_fl) {
     invisible(.Call(`_scPipe_rcpp_sc_gene_counting`, outdir, bc_anno, UMI_cor, gene_fl))
 }
 
-rcpp_sc_detect_bc <- function(infq, outcsv, suffix, bc_len, max_reads, number_of_cells, min_count, max_mismatch, white_list) {
-    invisible(.Call(`_scPipe_rcpp_sc_detect_bc`, infq, outcsv, suffix, bc_len, max_reads, number_of_cells, min_count, max_mismatch, white_list))
+rcpp_sc_detect_bc <- function(infq, outcsv, prefix, bc_len, max_reads, number_of_cells, min_count, max_mismatch, white_list) {
+    invisible(.Call(`_scPipe_rcpp_sc_detect_bc`, infq, outcsv, prefix, bc_len, max_reads, number_of_cells, min_count, max_mismatch, white_list))
 }
 

--- a/R/wrapper_scPipeCPP.R
+++ b/R/wrapper_scPipeCPP.R
@@ -334,7 +334,7 @@ sc_gene_counting = function(outdir, bc_anno, UMI_cor=2, gene_fl=FALSE) {
 #' @param infq input fastq file, shoule be the output file of
 #' \code{sc_trim_barcode}
 #' @param outcsv output barcode annotation
-#' @param suffix the suffix of cell name (default: `CELL_`)
+#' @param prefix the prefix of cell name (default: `CELL_`)
 #' @param bc_len the length of cell barcode, should be consistent with bl1+bl2
 #' in \code{sc_trim_barcode}
 #' @param max_reads the maximum of reads processed (default: 1,000,000)
@@ -359,7 +359,7 @@ sc_gene_counting = function(outdir, bc_anno, UMI_cor=2, gene_fl=FALSE) {
 #' }
 #'
 #'
-sc_detect_bc = function(infq, outcsv, suffix="CELL_", bc_len,
+sc_detect_bc = function(infq, outcsv, prefix="CELL_", bc_len,
                         max_reads=1000000, min_count=10, number_of_cells=10000,
                         max_mismatch=1,white_list_file=NULL) {
   if (!file.exists(infq)) {
@@ -376,7 +376,7 @@ sc_detect_bc = function(infq, outcsv, suffix="CELL_", bc_len,
   }
   if (max_reads=="all") {m_r = -1}
   else {m_r=max_reads}
-  rcpp_sc_detect_bc(infq, outcsv, suffix, bc_len, m_r, number_of_cells, 
+  rcpp_sc_detect_bc(infq, outcsv, prefix, bc_len, m_r, number_of_cells, 
     min_count, max_mismatch, white_list_file)
 }
 

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -111,8 +111,16 @@
   }
 }
 
+\section{Changes in version 1.3.7 (2018-6-23)}{
+  \itemize{
+    \item added multithreading to `parse_align`
+    \item added nthreads argument to `parse_align` and all upstream wrappers
+  }
+}
+
 \section{Changes in version 1.3.8 (2018-6-27)}{
   \itemize{
     \item fix a minor bug in cell barcode demultiplexing
+    \item corrected `suffix` argument in `sc_detect_bc` to `prefix`
   }
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -84,20 +84,20 @@ BEGIN_RCPP
 END_RCPP
 }
 // rcpp_sc_detect_bc
-void rcpp_sc_detect_bc(Rcpp::CharacterVector infq, Rcpp::CharacterVector outcsv, Rcpp::CharacterVector suffix, Rcpp::NumericVector bc_len, Rcpp::NumericVector max_reads, Rcpp::NumericVector number_of_cells, Rcpp::NumericVector min_count, Rcpp::NumericVector max_mismatch, Rcpp::CharacterVector white_list);
-RcppExport SEXP _scPipe_rcpp_sc_detect_bc(SEXP infqSEXP, SEXP outcsvSEXP, SEXP suffixSEXP, SEXP bc_lenSEXP, SEXP max_readsSEXP, SEXP number_of_cellsSEXP, SEXP min_countSEXP, SEXP max_mismatchSEXP, SEXP white_listSEXP) {
+void rcpp_sc_detect_bc(Rcpp::CharacterVector infq, Rcpp::CharacterVector outcsv, Rcpp::CharacterVector prefix, Rcpp::NumericVector bc_len, Rcpp::NumericVector max_reads, Rcpp::NumericVector number_of_cells, Rcpp::NumericVector min_count, Rcpp::NumericVector max_mismatch, Rcpp::CharacterVector white_list);
+RcppExport SEXP _scPipe_rcpp_sc_detect_bc(SEXP infqSEXP, SEXP outcsvSEXP, SEXP prefixSEXP, SEXP bc_lenSEXP, SEXP max_readsSEXP, SEXP number_of_cellsSEXP, SEXP min_countSEXP, SEXP max_mismatchSEXP, SEXP white_listSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type infq(infqSEXP);
     Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type outcsv(outcsvSEXP);
-    Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type suffix(suffixSEXP);
+    Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type prefix(prefixSEXP);
     Rcpp::traits::input_parameter< Rcpp::NumericVector >::type bc_len(bc_lenSEXP);
     Rcpp::traits::input_parameter< Rcpp::NumericVector >::type max_reads(max_readsSEXP);
     Rcpp::traits::input_parameter< Rcpp::NumericVector >::type number_of_cells(number_of_cellsSEXP);
     Rcpp::traits::input_parameter< Rcpp::NumericVector >::type min_count(min_countSEXP);
     Rcpp::traits::input_parameter< Rcpp::NumericVector >::type max_mismatch(max_mismatchSEXP);
     Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type white_list(white_listSEXP);
-    rcpp_sc_detect_bc(infq, outcsv, suffix, bc_len, max_reads, number_of_cells, min_count, max_mismatch, white_list);
+    rcpp_sc_detect_bc(infq, outcsv, prefix, bc_len, max_reads, number_of_cells, min_count, max_mismatch, white_list);
     return R_NilValue;
 END_RCPP
 }

--- a/src/detect_barcode.cpp
+++ b/src/detect_barcode.cpp
@@ -160,7 +160,7 @@ std::unordered_map<std::string, int> summarize_barcode(std::string fn, int bc_le
     return counter;
 }
 
-void write_barcode_summary(std::string outfn, std::string suffix, std::unordered_map<std::string, int> counter, int number_of_cells)
+void write_barcode_summary(std::string outfn, std::string prefix, std::unordered_map<std::string, int> counter, int number_of_cells)
 {
     std::ofstream o_file(outfn);  // output file
     int cnt = 0;
@@ -178,7 +178,7 @@ void write_barcode_summary(std::string outfn, std::string suffix, std::unordered
     std::reverse(items.begin(),items.end()); // highest -> lowest
     for (auto const& bc: items)
     {
-        o_file << suffix << padding(cnt, dig) << "," << bc.second << "," << bc.first << "\n";
+        o_file << prefix << padding(cnt, dig) << "," << bc.second << "," << bc.first << "\n";
         cnt++;
         if(number_of_cells > 0 && cnt > number_of_cells)
         {

--- a/src/detect_barcode.h
+++ b/src/detect_barcode.h
@@ -27,7 +27,7 @@ std::unordered_map<std::string, int> summarize_barcode(
 
 void write_barcode_summary(
     std::string outfn,
-    std::string surfix,
+    std::string prefix,
     std::unordered_map<std::string, int> counter,
     int number_of_cells
 );

--- a/src/rcpp_scPipe_func.cpp
+++ b/src/rcpp_scPipe_func.cpp
@@ -205,7 +205,7 @@ void rcpp_sc_gene_counting(Rcpp::CharacterVector outdir,
 
 void rcpp_sc_detect_bc(Rcpp::CharacterVector infq,
                            Rcpp::CharacterVector outcsv,
-                           Rcpp::CharacterVector suffix,
+                           Rcpp::CharacterVector prefix,
                            Rcpp::NumericVector bc_len,
                            Rcpp::NumericVector max_reads,
                            Rcpp::NumericVector number_of_cells,
@@ -215,7 +215,7 @@ void rcpp_sc_detect_bc(Rcpp::CharacterVector infq,
 {
   std::string c_infq = Rcpp::as<std::string>(infq);
   std::string c_outcsv = Rcpp::as<std::string>(outcsv);
-  std::string c_suffix = Rcpp::as<std::string>(suffix);
+  std::string c_prefix = Rcpp::as<std::string>(prefix);
   std::string c_white_list = Rcpp::as<std::string>(white_list);
   int c_bc_len = Rcpp::as<int>(bc_len);
   int c_max_reads = Rcpp::as<int>(max_reads);
@@ -224,6 +224,6 @@ void rcpp_sc_detect_bc(Rcpp::CharacterVector infq,
   int c_number_of_cells = Rcpp::as<int>(number_of_cells);
   
   std::unordered_map<std::string, int> counter = summarize_barcode(c_infq, c_bc_len, c_max_reads, c_max_mismatch, c_min_count, c_white_list);
-  write_barcode_summary(c_outcsv, c_suffix, counter, c_number_of_cells);
+  write_barcode_summary(c_outcsv, c_prefix, counter, c_number_of_cells);
 }
 

--- a/src/transcriptmapping.cpp
+++ b/src/transcriptmapping.cpp
@@ -336,7 +336,7 @@ void GeneAnnotation::parse_gff3_annotation(string gff3_fn, bool fix_chrname)
         auto &current_genes = gene_dict[chr_name];
         // sort genes based on starting position
         sort(current_genes.begin(), current_genes.end(),
-            [] (Gene &g1, Gene &g2) { return g1.st < g2.st; }
+            [] (const Gene &g1, const Gene &g2) { return g1.st < g2.st; }
         );
 
         // create bins of genes		
@@ -385,7 +385,7 @@ void GeneAnnotation::parse_bed_annotation(string bed_fn, bool fix_chrname)
         if (gene_dict[iter.first].size()>1)
         {
             sort(gene_dict[iter.first].begin(), gene_dict[iter.first].end(),
-                [] (Gene &g1, Gene &g2) { return g1.st < g2.st; }
+                [] (const Gene &g1, const Gene &g2) { return g1.st < g2.st; }
             );
         }
 


### PR DESCRIPTION
The suffix argument in `sc_detect_bc` is actually a prefix. Changed all references to this argument to prefix.

* Added const specifiers to lambdas used for sorting. GCC 4.8 requires this even though it's not actually required by C++11, and GCC 4.9 removes this requirement. 