### PR TITLE
Document that output of sc_trim_barcode() can be automatically gzipped

### DIFF
--- a/R/wrapper_scPipeCPP.R
+++ b/R/wrapper_scPipeCPP.R
@@ -21,7 +21,7 @@
 #'
 #' @name sc_trim_barcode
 #' @param outfq the output fastq file, which reformat the barcode and UMI into
-#'   the read name.
+#'   the read name. Files ending in \code{.gz} will be automatically compressed.
 #' @param r1 read one for pair-end reads. This read should contain
 #'   the transcript.
 #' @param r2 read two for pair-end reads, NULL if single read.

--- a/man/sc_trim_barcode.Rd
+++ b/man/sc_trim_barcode.Rd
@@ -10,7 +10,7 @@ sc_trim_barcode(outfq, r1, r2 = NULL, read_structure = list(bs1 = -1, bl1 =
 }
 \arguments{
 \item{outfq}{the output fastq file, which reformat the barcode and UMI into
-the read name.}
+the read name. Files ending in \code{.gz} will be automatically compressed.}
 
 \item{r1}{read one for pair-end reads. This read should contain
 the transcript.}

--- a/vignettes/scPipe_tutorial.Rmd
+++ b/vignettes/scPipe_tutorial.Rmd
@@ -52,7 +52,7 @@ fq_R2 = system.file("extdata", "simu_R2.fastq.gz", package = "scPipe")
 The pipeline starts with fastq file reformatting. We move the barcode and UMI sequences to the read name and leave the transcript sequence as is. This outputs a read name that looks like `@[barcode_sequence]*[UMI_sequence]#[readname]` ... The read structure of read 2 in our example dataset has the 8 bp long cell barcode starting at position 6 and the 6 bp long UMI sequence starting at the first position. So the read structure will be : `list(bs1=-1, bl1=0, bs2=6, bl2=8, us=0, ul=6)`. `bs1=-1, bl1=0` means we don't have an index in read 1 so we set a negative value as its start position and give it zero length. `bs2=6, bl2=8` means we have an index in read two which starts at position 6 in the read and is 8 bases in length. `us=0, ul=6` means we have a UMI at the start of read 2 which is 6 bases long. **NOTE**: we use a zero based index system, so the indexing of the sequence starts at zero.
 
 ```{r,eval=TRUE}
-sc_trim_barcode(file.path(data_dir, "combined.fastq"),
+sc_trim_barcode(file.path(data_dir, "combined.fastq.gz"),
                 fq_R1,
                 fq_R2,
                 read_structure = list(bs1=-1, bl1=0, bs2=6, bl2=8, us=0, ul=6))
@@ -67,7 +67,7 @@ if(.Platform$OS.type != "windows"){
   Rsubread::buildindex(basename=file.path(data_dir, "ERCC_index"), reference=ERCCfa_fn)
 
   Rsubread::align(index=file.path(data_dir, "ERCC_index"),
-      readfile1=file.path(data_dir, "combined.fastq"),
+      readfile1=file.path(data_dir, "combined.fastq.gz"),
       output_file=file.path(data_dir, "out.aln.bam"), phredOffset=64)
 }
 ```


### PR DESCRIPTION
I updated the documentation to mention this really useful feature!
Note, I ran `devtools::document()` which used **roxygen 6.1.0** rather than your current **6.0.1** 
https://github.com/LuyiTian/scPipe/blob/80b253de39df256b00ba3d1fbac3824c24227b7f/DESCRIPTION#L23

This caused some minor tweaks to `.Rd` files that aren't related to my changes, so I haven't included these in this pull request.