### PR TITLE
Fixed sc_trim_fastq() not working when outfq is just a file name with no parent folder

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,7 +47,7 @@ Imports:
     dplyr,
     GenomicRanges,
     magrittr,
-    glue,
+    glue (>= 1.3.0),
     rlang
 License: GPL (>= 2)
 Encoding: UTF-8

--- a/R/wrapper_scPipeCPP.R
+++ b/R/wrapper_scPipeCPP.R
@@ -65,7 +65,7 @@ sc_trim_barcode = function(outfq, r1, r2=NULL,
                              rmlow=TRUE, rmN=TRUE, minq=20, numbq=2)) {
 
   outdir <- regmatches(outfq, regexpr(".*/", outfq))
-  if (!dir.exists(outdir))
+  if (outdir != character(0) && !dir.exists(outdir))
     dir.create(outdir, recursive = TRUE)
 
   if (filter_settings$rmlow) {
@@ -297,7 +297,7 @@ sc_demultiplex = function(inbam, outdir, bc_anno,
 #' sc_correct_bam_bc
 #'
 #' @description update the cell barcode tag in bam file with corrected barcode
-#' output to a new bam file. the function will be useful for methods 
+#' output to a new bam file. the function will be useful for methods
 #' that use the cell barcode information from bam file, such as `Demuxlet`
 #'
 #' @param inbam input bam file. This should be the output of


### PR DESCRIPTION
* Fixed `sc_trim_fastq()` not working when `outfq` is just a file name with no parent folder
* Added version number dependency to `glue` since I use `glue_collapse()` which is only available from v1.3.0 onwards

[This](https://github.com/Shians/scPipe/blob/c14c29c1c8951ae9b0837e781f683f132a3d01fd/R/wrapper_scPipeCPP.R#L67) I added this regular expression to extract the parent folders of a path, but if there are no parent folders it returns an empty expression and causes an error. This is fixed by adding the first condition in [this](https://github.com/Shians/scPipe/blob/c14c29c1c8951ae9b0837e781f683f132a3d01fd/R/wrapper_scPipeCPP.R#L68) conditional.
