### PR TITLE
Fixes #117

### DIFF
--- a/R/anno_import.R
+++ b/R/anno_import.R
@@ -34,7 +34,9 @@ anno_import <- function(filename) {
     }
 
     anno <- lapply(filename, rtracklayer::import)
-    anno <- lapply(anno, anno_to_saf)
+    for (i in seq_along(anno)) {
+        anno[[i]] <- anno_to_saf(anno[[i]])
+    }
 
     # gene_id column is present and contains necessary information
     # return SAF converted data.frame
@@ -84,11 +86,8 @@ anno_to_saf <- function(anno) {
         stop("'type' column missing from GRanges metadata")
     }
 
-    missing_gene_id <- is.null(anno$gene_id)
-    if (missing_gene_id) {
-        anno <- infer_gene_ids(anno)
-        meta_cols <- colnames(GenomicRanges::mcols(anno))
-    }
+    anno <- infer_gene_ids(anno)
+    meta_cols <- colnames(GenomicRanges::mcols(anno))
 
     if (!"gene_id" %in% meta_cols) {
         stop("'gene_id' column missing from GRanges metadata and could not be inferred")

--- a/R/anno_import.R
+++ b/R/anno_import.R
@@ -34,9 +34,7 @@ anno_import <- function(filename) {
     }
 
     anno <- lapply(filename, rtracklayer::import)
-    for (i in seq_along(anno)) {
-        anno[[i]] <- anno_to_saf(anno[[i]])
-    }
+    anno <- lapply(anno, anno_to_saf)
 
     # gene_id column is present and contains necessary information
     # return SAF converted data.frame
@@ -119,7 +117,7 @@ anno_to_saf <- function(anno) {
         saf <- saf %>%
             dplyr::filter(!is.na(GeneID))
         filt_rows <- nrow(saf)
-        warning(glue::glue("NA found in GeneID of {orig_rows - filt_rows} of {orig_rows} entries, automatically removing these entries"))
+        message(glue::glue("NA found in GeneID of {orig_rows - filt_rows} of {orig_rows} entries, automatically removing these entries"))
     }
 
     saf %>% dplyr::select(.data$GeneID, dplyr::everything())
@@ -171,8 +169,8 @@ infer_gene_ids <- function(anno) {
 fmt_str <- stringr::str_interp
 
 infer_gene_id_from_dbx <- function(anno) {
-    extract_gene_id <- function(x) {
-        sapply(x, function(x) x[stringr::str_detect(x, "GeneID")][1]) %>%
+    extract_gene_id <- function(anno) {
+        sapply(anno, function(x) x[stringr::str_detect(x, "GeneID")][1]) %>%
             stringr::str_extract("GeneID:[^,]+") %>%
             stringr::str_remove("GeneID:")
     }

--- a/R/anno_import.R
+++ b/R/anno_import.R
@@ -190,7 +190,7 @@ infer_gene_id_from_parent <- function(anno) {
         transcripts <- anno %>%
             as.data.frame() %>%
             dplyr::filter(!is.na(.data$transcript_id)) %>%
-            dplyr::select(t"ranscript_id", "Parent") %>%
+            dplyr::select("transcript_id", "Parent") %>%
             dplyr::mutate(
                 transcript_id = paste0("transcript:", .data$transcript_id),
                 Parent = stringr::str_remove(.data$Parent, "gene:")


### PR DESCRIPTION
This pull request addresses #117 and #116. With the manual removal of the unreasonably long entries, the GFF becomes parsable, but scPipe could not process the Dbxref column correctly because "GeneID" is usually the first element. After the changes the GFF will be processed, but GeneIDs could not be found in some exons and a message is produced:  `NA found in GeneID of 222 of 324663 entries, automatically removing these entries`.