### PR TITLE
Changed hashmap to hash because hashmap is deprecated

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: scPipe
 Title: pipeline for single cell RNA-seq data analysis
 Date: 2019-10-12
-Version: 1.9.3
+Version: 1.9.4
 Type: Package
 Maintainer: Luyi Tian <tian.l@wehi.edu.au>
 Author: Luyi Tian
@@ -45,7 +45,7 @@ Imports:
     org.Mm.eg.db,
     stringr,
     rtracklayer,
-    hashmap,
+    hash,
     dplyr,
     GenomicRanges,
     magrittr,

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -165,3 +165,9 @@
     \item Changed instances of deprecated `plotQC()` to `plotHighestExprs()`
   }
 }
+
+\section{Changes in version 1.9.4 (2020-04-06)}{
+  \itemize{
+    \item Changed hashmap package calls to hash package as hashmap is no longer on CRAN.
+  }
+}

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -153,7 +153,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_scPipe_rcpp_sc_clean_bam", (DL_FUNC) &_scPipe_rcpp_sc_clean_bam, 10},
     {"_scPipe_rcpp_sc_gene_counting", (DL_FUNC) &_scPipe_rcpp_sc_gene_counting, 4},
     {"_scPipe_rcpp_sc_detect_bc", (DL_FUNC) &_scPipe_rcpp_sc_detect_bc, 9},
-    {"run_testthat_tests",                   (DL_FUNC) &run_testthat_tests,                    0},
+    {"run_testthat_tests", (DL_FUNC) &run_testthat_tests, 0},
     {NULL, NULL, 0}
 };
 

--- a/src/parsebam.cpp
+++ b/src/parsebam.cpp
@@ -74,9 +74,11 @@ int Bamdemultiplex::clean_bam_barcode(string bam_path, string out_bam, int max_m
     bam1_t *b = bam_init1();
     BGZF *fp = bgzf_open(bam_path.c_str(), "r");
     bam_hdr_t *header = bam_hdr_read(fp);
+    
+    int hts_retcode;
 
     samFile *of = sam_open(out_bam.c_str(), "wb"); // output file
-    sam_hdr_write(of, header);
+    hts_retcode = sam_hdr_write(of, header); // (void) explicitly discard return value
 
     // Early benchmarking shows BAM reading doesn't saturate even 2 cores
     // so capped reading threads to 2
@@ -127,7 +129,7 @@ int Bamdemultiplex::clean_bam_barcode(string bam_path, string out_bam, int max_m
         if ((!is_unmapped) & (!match_res.empty())) 
         {
             bam_aux_update_str(b, c_ptr, match_res.length()+1, match_res.c_str());
-            sam_write1(of, header, b);
+            hts_retcode = sam_write1(of, header, b); // (void) discards return value
         }
     }
 

--- a/src/transcriptmapping.cpp
+++ b/src/transcriptmapping.cpp
@@ -752,8 +752,10 @@ void Mapping::parse_align(string bam_fn, string fn_out, bool m_strand, string ma
     p.pool = hts_tpool_init(out_threads);
     hts_set_opt(of, HTS_OPT_THREAD_POOL, &p);
 
+    int hts_retcode;
+
     bam_hdr_t *header = bam_hdr_read(fp);
-    sam_hdr_write(of, header);
+    hts_retcode = sam_hdr_write(of, header);
 
     int tmp_c[4] = {0,0,0,0};
 

--- a/src/trimbarcode.cpp
+++ b/src/trimbarcode.cpp
@@ -89,7 +89,8 @@ void paired_fastq_to_bam(char *fq1_fn, char *fq2_fn, char *bam_out, const read_s
     hdr->l_text = strlen(empty_header);
     hdr->text = strdup(empty_header);
     hdr->n_targets = 0;
-    sam_hdr_write(fp, hdr);
+    int hts_retcode;
+    hts_retcode = sam_hdr_write(fp, hdr);
 
     // get settings
     int id1_st = read_structure.id1_st;

--- a/tests/testthat/test-anno_import.R
+++ b/tests/testthat/test-anno_import.R
@@ -17,8 +17,16 @@ test_that("ENSEMBL gtf annotation can be imported", {
 test_that("Common annotation sources can be imported", {
     expect_silent(anno_import(system.file("extdata", "ens_tiny_anno.gff3.gz", package = "scPipe")))
     expect_silent(anno_import(system.file("extdata", "ens_tiny_anno.gtf.gz", package = "scPipe")))
+    expect_equal(
+        anno_import(system.file("extdata", "ens_tiny_anno.gff3.gz", package = "scPipe")),
+        anno_import(system.file("extdata", "ens_tiny_anno.gtf.gz", package = "scPipe"))
+    )
     expect_silent(anno_import(system.file("extdata", "gen_tiny_anno.gff3.gz", package = "scPipe")))
     expect_silent(anno_import(system.file("extdata", "gen_tiny_anno.gtf.gz", package = "scPipe")))
+    expect_equal(
+        anno_import(system.file("extdata", "gen_tiny_anno.gff3.gz", package = "scPipe")),
+        anno_import(system.file("extdata", "gen_tiny_anno.gtf.gz", package = "scPipe"))
+    )
     expect_silent(anno_import(system.file("extdata", "ref_tiny_anno.gff3.gz", package = "scPipe")))
 })
 


### PR DESCRIPTION
* Changed usage of hashmap package to hash package. Since hashmap package is no longer on CRAN.
* Added some return code captures in C++ code to avoid warnings.