### PR TITLE
Use `drop = FALSE` when subsetting matrices

### DIFF
--- a/R/qc.R
+++ b/R/qc.R
@@ -253,8 +253,8 @@ calculate_QC_metrics <- function(sce) {
 
   # get ERCC ratio
   if(any(grepl("^ERCC-", rownames(sce)))){
-    exon_count = colSums(assay(sce,"counts")[!grepl("^ERCC-", rownames(sce)),])
-    ERCC_count = colSums(assay(sce,"counts")[grepl("^ERCC-", rownames(sce)),])
+    exon_count = colSums(assay(sce,"counts")[!grepl("^ERCC-", rownames(sce)), , drop = FALSE])
+    ERCC_count = colSums(assay(sce,"counts")[grepl("^ERCC-", rownames(sce)), , drop = FALSE])
     QC_metrics(sce)$non_ERCC_percent = exon_count/(ERCC_count+exon_count+1e-5)
   }else{
       message("no ERCC spike-in. Skip `non_ERCC_percent`")
@@ -267,7 +267,7 @@ calculate_QC_metrics <- function(sce) {
                                 go=c("GO:0005739"))
     if (length(mt_genes)>0) {
       if (sum(rownames(sce) %in% mt_genes)>1) {
-        mt_count <- colSums(assay(sce,"counts")[rownames(sce) %in% mt_genes, ])
+        mt_count <- colSums(assay(sce,"counts")[rownames(sce) %in% mt_genes, , drop = FALSE])
         QC_metrics(sce)$non_mt_percent <- (colSums(assay(sce,"counts"))-
                                              mt_count)/(colSums(assay(sce,"counts"))+1e-5)
         # add 1e-5 to make sure they are not NA


### PR DESCRIPTION
This was failing for me when I only had 1 ERCC detected.
In that case, `colSums(assay(sce,"counts")[grepl("^ERCC-", rownames(sce)), ])` gives an error because it tries to compute the `colSums()` of a vector.
E.g.,

``` r
x <- matrix(1:12, nrow = 3)

# Fails because x[1, ] is no longer a matrix.
colSums(x[1, ])
#> Error in colSums(x[1, ]): 'x' must be an array of at least two dimensions
x[1, ]
#> [1]  1  4  7 10
class(x[1, ])
#> [1] "integer"

# Succeeds because x[1, , drop = FALSE] is preserved as a matrix
colSums(x[1, , drop = FALSE])
#> [1]  1  4  7 10
x[1, , drop = FALSE]
#>      [,1] [,2] [,3] [,4]
#> [1,]    1    4    7   10
class(x[1, , drop = FALSE])
#> [1] "matrix" "array"
```

There are likely other instances in **scPipe** of this underlying bug, I've only fixed some I could immediately spot in `calculate_QC_metrics()`.